### PR TITLE
Reduce token vault name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ This will install the required Python packages in a virtual environment.
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -71,13 +71,11 @@ resource "azurerm_role_assignment" "storage_blob_contributor" {
 data "azurerm_client_config" "this" {}
 
 resource "azurerm_key_vault" "sas_token_vault" {
-  name                = "${var.prefix}-sas-token-vault"
+  name                = "${var.prefix}-sas-tv"
   resource_group_name = var.resource_group_name
   location            = var.location
   sku_name            = "standard"
   tenant_id           = data.azurerm_client_config.this.tenant_id
-
-
 
   access_policy {
     tenant_id = data.azurerm_client_config.this.tenant_id
@@ -112,4 +110,3 @@ data "external" "sas_token" {
   }
 
 }
-


### PR DESCRIPTION
As reported by @def-, this fixes:

```
│ Error: "name" may only contain alphanumeric characters and dashes and must be between 3-24 chars
│
│   with module.materialize.module.storage.azurerm_key_vault.sas_token_vault,
│   on .terraform/modules/materialize/modules/storage/main.tf line 74, in resource "azurerm_key_vault" "sas_token_vault":
│   74:   name                = "${var.prefix}-sas-token-vault"
```

Also created: https://github.com/MaterializeInc/terraform-azurerm-materialize/issues/8 as a follow up to just in general limit the length of the prefix var so people don't use crazy long strings.