### PR TITLE
use E8pds_v6 for vms and switch to premium storage with service accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,10 +50,14 @@ module "storage" {
   location              = var.location
   prefix                = var.prefix
   identity_principal_id = module.aks.workload_identity_principal_id
+  subnets               = [module.aks.subnet_id]
 
   tags = local.common_labels
 
-  depends_on = [module.aks]
+  # This seems to help us get through some timing 
+  # issues that required multiple deploys, but truly
+  # shouldn't be needed.
+  depends_on = [module.aks.subnet_id]
 }
 
 locals {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -23,3 +23,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "subnets" {
+  description = "the subnet of the vnet that should be able to access this storage account"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "aks_config" {
     max_nodes    = number
   })
   default = {
-    vm_size      = "Standard_D8s_v3"
+    vm_size      = "Standard_E8ps_v6"
     disk_size_gb = 100
     min_nodes    = 1
     max_nodes    = 5


### PR DESCRIPTION
Updated vm size to align more with the R8 choice on AWS, also moved to premium storage as it gave better reliability for TPC-H. We may be able to move back down to standard storage, but will need to do some testing first. 