### PR TITLE
Fix persist backend url output format

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -46,11 +46,10 @@ locals {
   )
 
   persist_backend_url = format(
-    "azblob://%s/%s?account=%s&container=%s",
-    module.storage.storage_account_key,
+    "%s%s?%s",
+    module.storage.primary_blob_endpoint,
     module.storage.container_name,
-    module.storage.storage_account_name,
-    module.storage.container_name
+    module.storage.primary_blob_sas_token
   )
 }
 


### PR DESCRIPTION
As noticed by @def-, the `persist_backend_url` output format was incorrect.

The format that we pass to envd was correct though, so it was only the output itself that was wrong:

https://github.com/MaterializeInc/terraform-azurerm-materialize/blob/ad6bba68e07484dfd2fd174d648455b823183811/main.tf#L93-L100