### PR TITLE
Remove `zone` from PostgreSQL Flexible Server configuration

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -16,8 +16,6 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
 
   backup_retention_days = 7
 
-  zone = "1"
-
   tags = var.tags
 }
 


### PR DESCRIPTION
This PR removes the `zone` explicit definition from the PostgreSQL Flexible Server resource in Terraform. 

From the [docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server):

> Azure will automatically assign an Availability Zone if one is not specified.
