### PR TITLE
Add random suffix to Postgres instance name

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_postgresql_flexible_server" "postgres" {
-  name                = "${var.prefix}-pg"
+  name                = "${var.prefix}-${random_string.postgres_name_suffix.result}-pg"
   resource_group_name = var.resource_group_name
   location            = var.location
   version             = var.postgres_version
@@ -22,4 +22,10 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
 resource "azurerm_postgresql_flexible_server_database" "materialize" {
   name      = var.database_name
   server_id = azurerm_postgresql_flexible_server.postgres.id
+}
+
+resource "random_string" "postgres_name_suffix" {
+  length  = 4
+  special = false
+  upper   = false
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
   administrator_login    = var.database_user
   administrator_password = var.password
 
-  storage_mb = 32768
+  storage_mb = var.storage_mb
   sku_name   = var.sku_name
 
   backup_retention_days = 7

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -16,6 +16,12 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
 
   backup_retention_days = 7
 
+  lifecycle {
+    ignore_changes = [
+      zone
+    ]
+  }
+
   tags = var.tags
 }
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -60,3 +60,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "storage_mb" {
+  description = "The storage capacity in MB"
+  type        = number
+  default     = 32768
+}


### PR DESCRIPTION
We have managed to track down #26 to an issue where Postgres creation fails if the name is already taken by another Postgres instance on Azure.

Adding a random string suffix to the instance name to help prevent that.

Fixes #26 