### PR TITLE
Bump for terraform-helm-materialize v0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module sets up:
 The module has been tested with:
 - AKS version 1.28
 - PostgreSQL 15
-- Materialize Operator v0.1.0
+- terraform-helm-materialize v0.1.12 (Materialize Operator v25.1.7)
 
 ## Setup Notes:
 
@@ -89,7 +89,7 @@ No providers.
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
 | <a name="module_load_balancers"></a> [load\_balancers](#module\_load\_balancers) | ./modules/load_balancers | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.11 |
+| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.12 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 
 ## Resources

--- a/docs/header.md
+++ b/docs/header.md
@@ -19,7 +19,7 @@ This module sets up:
 The module has been tested with:
 - AKS version 1.28
 - PostgreSQL 15
-- Materialize Operator v0.1.0
+- terraform-helm-materialize v0.1.12 (Materialize Operator v25.1.7)
 
 ## Setup Notes:
 

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ locals {
 }
 
 module "operator" {
-  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.11"
+  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.12"
 
   count = var.install_materialize_operator ? 1 : 0
 


### PR DESCRIPTION
Did the verified via `kubectl describe`

- `Successfully pulled image "materialize/orchestratord:v0.138.0"`
- `Successfully pulled image "materialize/environmentd:v0.130.8" in 4.201s` 

and via console as well.